### PR TITLE
integers passed as floats will be accepted

### DIFF
--- a/model/config.py
+++ b/model/config.py
@@ -88,11 +88,17 @@ class Config:
         if move_step <= 0:
             return False
 
+        # test if a float is really an integer (1.0)
+        if move_step.is_integer():
+            return True
+
         # if move_step is a float it must divide
         # the interval between 0 and 1 evenly
         if isinstance(move_step, float):
             if not (1/(move_step % 1)).is_integer():
                 return False
+
+        # integers are always accepted
         return True
 
     def get_types(self):


### PR DESCRIPTION
the function in the config module that checks the validity of step sizes will accept integers if passed as float (1.0 instead of 1). This fix will solve [Issue ä25](https://github.com/clp-research/golmi/issues/25)