### PR TITLE
combine area_target and create_targets into one parameter, rename area_block to obj_area

### DIFF
--- a/app/pentomino/static/js/pentomino.js
+++ b/app/pentomino/static/js/pentomino.js
@@ -58,9 +58,8 @@ $(document).ready(function () {
             socket.emit("random_init", {"n_objs": N_OBJECTS,
                                         "n_grippers": N_GRIPPERS,
                                         "random_gr_position":false,
-                                        "create_targets": true,
-                                        "area_block": "top",
-                                        "area_target": "bottom"});
+                                        "obj_area": "top",
+                                        "target_area": "bottom"});
             // manually add a gripper that will be assigned to the controller
             // TODO: Should this happen somewhere else?
             // Options:

--- a/model/generator.py
+++ b/model/generator.py
@@ -90,8 +90,8 @@ class Generator:
         return (x_start, x_end), (y_start, y_end)
 
     def _generate_target(
-            self, target_grid, index, piece_type,
-            width, height, block_matrix, area, color):
+            self, target_grid: Grid, index, piece_type, width, height,
+            block_matrix, area, color):
         """
         this function generates a target block for the object maintaining:
             - index
@@ -149,7 +149,7 @@ class Generator:
 
         return target_obj
 
-    def _generate_objects(self, n_objs, area_block, area_target, create_tgts):
+    def _generate_objects(self, n_objs, obj_area, target_area):
         objects = dict()
         targets = dict()
         attempt = 0
@@ -157,7 +157,7 @@ class Generator:
         target_grid = Grid.create_from_config(self.config)
 
         (x_start, x_end), (y_start, y_end) = self._restricted_coordinates(
-            area_block
+            obj_area
         )
 
         while len(objects) < n_objs:
@@ -209,14 +209,14 @@ class Generator:
                 object_grid.add_obj(obj)
 
                 # create a target
-                if create_tgts:
+                if target_area is not None:
                     target_obj = self._generate_target(
                         target_grid,
                         index,
                         piece_type,
                         width, height,
                         block_matrix,
-                        area_target,
+                        target_area,
                         color
                     )
 
@@ -235,16 +235,14 @@ class Generator:
         return objects, targets
 
     def generate_random_state(
-            self, n_objs, n_grippers, area_block="all",
-            area_target="all", create_targets=False,
-            random_gr_position=False):
+            self, n_objs, n_grippers, obj_area="all",
+            target_area="all", random_gr_position=False):
         # get grippers
         grippers = self._generate_grippers(n_grippers, random_gr_position)
 
         # get objects
         objects, target_objs = self._generate_objects(
-            n_objs, area_block, area_target, create_targets
-        )
+            n_objs, obj_area, target_area)
 
         # return a new state from generated objects, targets and grippers
         return State(objects, grippers, target_objs, self.config)

--- a/model/model.py
+++ b/model/model.py
@@ -81,17 +81,14 @@ class Model:
 
     # --- Set up and configuration --- #
 
-    def set_random_state(self, n_objs, n_grippers, area_block="all",
-                         area_target="all", create_targets=False,
-                         random_gr_position=False):
+    def set_random_state(self, n_objs, n_grippers, obj_area="all",
+                         target_area="all", random_gr_position=False):
         # we could possibly hold a generator instance as well
         generator = Generator(self.config)
 
         # generate state and grids
         new_state = generator.generate_random_state(
-             n_objs, n_grippers, area_block, area_target,
-             create_targets, random_gr_position
-        )
+             n_objs, n_grippers, obj_area, target_area, random_gr_position)
 
         self.set_state(new_state)
 


### PR DESCRIPTION
Random initialization was refactored:

* `area_block` and `area_target` are renamed to `obj_area` and `target_area`
* only one parameter is used for target creation instead of two: if no targets are wanted, set target_area to None / null, otherwise specify the area as before (e.g., "bottom")

Closes #35.

*(These are the same updates as in #36, but reapplied to the current master branch. It was hard to see the actual changes with the old branch.)*