### PR TITLE
fix use of action_interval for 'move' type actions

### DIFF
--- a/model/model.py
+++ b/model/model.py
@@ -391,7 +391,7 @@ class Model:
     def _loop(self, fn, *args, **kwargs):
         # rotations and flips can be slow (0.5)
         # movements should be as fast as in config
-        if args[0] == "move":
+        if args[1] == "move":
             action_interval = self.config.action_interval
         else:
             action_interval = 0.5

--- a/model/mover.py
+++ b/model/mover.py
@@ -132,6 +132,7 @@ class Mover:
         """
         this method applies a movement.
         Parameters:
+            - Model instance
             - movement type {"move", "flip", "rotate"}
             - gr_id: id of the gripper
 


### PR DESCRIPTION
Movement speed is now back to normal.

* Fixed #39 with the least number of changes: in model._loop, simply check arg 1 instead of arg 0 where the action type is passed after the most recent PR (#34). (The other option would have been to change the order in mover.apply_movement).
* Updated documentation to mover.apply_movement. 