### PR TITLE
Fix and refactor config

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,3 +1,6 @@
+import json
+from os.path import exists
+
 from flask import Flask, request
 from flask_cors import CORS
 from flask_socketio import (
@@ -9,7 +12,7 @@ from app import DEFAULT_CONFIG_FILE
 
 # has to be passed by clients to connect
 # might want to set this in the environment variables:
-# AUTH = os.environ['GOLMI_AUTH']
+# AUTH = os.environ["GOLMI_AUTH"]
 AUTH = "GiveMeTheBigBluePasswordOnTheLeft"
 app = Flask(__name__)
 # --- app settings --- #
@@ -19,7 +22,7 @@ app = Flask(__name__)
 # (This is the recommendation by the Flask documentation:
 # https://flask.palletsprojects.com/en/2.0.x/quickstart/#sessions)
 app.config["SECRET_KEY"] = "change this to some random value!".encode("utf-8")
-app.config['CORS_HEADERS'] = 'Content-Type'
+app.config["CORS_HEADERS"] = "Content-Type"
 
 # enable cross-origin requests
 # TODO: restrict sources
@@ -29,7 +32,7 @@ socketio = SocketIO(
     app,
     logger=True,
     engineio_logger=True,
-    cors_allowed_origins='*'
+    cors_allowed_origins="*"
 )
 room_manager = RoomManager(socketio)
 
@@ -64,6 +67,19 @@ def param_is_integer(param):
     return isinstance(param, int) or (isinstance(param, float) and param.is_integer())
 
 
+def get_default_config():
+    """
+    @return default Model configuration as a dictionary
+    """
+    if DEFAULT_CONFIG_FILE not in app.config:
+        raise RuntimeError(f"{DEFAULT_CONFIG_FILE} not set")
+    elif not exists(app.config[DEFAULT_CONFIG_FILE]):
+        raise RuntimeError(f"file {app.config[DEFAULT_CONFIG_FILE]} not found")
+    with open(app.config[DEFAULT_CONFIG_FILE], mode="r") as default_file:
+        default_config = default_file.read()
+    return json.loads(default_config)
+
+
 # --- socketio events --- #
 # --- connection --- #
 @socketio.on("connect")
@@ -85,11 +101,11 @@ def join(params):
 
         if not room_manager.has_room(room_id):
             # create a new default room
-            room_manager.add_room(room_id, app.config[DEFAULT_CONFIG_FILE])
+            room_manager.add_room(room_id, get_default_config())
     else:
         # client gets their own default room
         room_id = request.sid + "_room"
-        room_manager.add_room(room_id, app.config[DEFAULT_CONFIG_FILE])
+        room_manager.add_room(room_id, get_default_config())
 
     room_manager.add_client_to_room(request.sid, room_id)
 
@@ -122,8 +138,10 @@ def reset_state():
 # --- configuration --- #
 @socketio.on("load_config")
 def load_config(json):
+    new_config = get_default_config()
+    new_config.update(json)
     for model in room_manager.get_models_of_client(request.sid):
-        model.set_config(json)
+        model.set_config(new_config)
 
 
 # --- pieces --- #

--- a/app/app.py
+++ b/app/app.py
@@ -1,5 +1,5 @@
 import json
-from os.path import exists
+from os.path import isfile
 
 from flask import Flask, request
 from flask_cors import CORS
@@ -75,7 +75,7 @@ def get_default_config():
     """
     if DEFAULT_CONFIG_FILE not in app.config:
         raise RuntimeError(f"{DEFAULT_CONFIG_FILE} not set")
-    elif not exists(app.config[DEFAULT_CONFIG_FILE]):
+    elif not isfile(app.config[DEFAULT_CONFIG_FILE]):
         raise RuntimeError(f"file {app.config[DEFAULT_CONFIG_FILE]} not found")
     with open(app.config[DEFAULT_CONFIG_FILE], mode="r") as default_file:
         default_config = default_file.read()

--- a/app/app.py
+++ b/app/app.py
@@ -139,10 +139,24 @@ def reset_state():
 # --- configuration --- #
 @socketio.on("load_config")
 def load_config(json):
+    """For each model belonging to the sending client, set a new config with the
+    given keys, all other keys left to default.
+    """
     new_config = get_default_config()
     new_config.update(json)
     for model in room_manager.get_models_of_client(request.sid):
         model.set_config(new_config)
+
+
+@socketio.on("update_config")
+def update_config(json):
+    """For each model belonging to the sending client, update the existing
+    config with the given keys, preserving previous settings.
+    """
+    for model in room_manager.get_models_of_client(request.sid):
+        updated_config = model.get_config()
+        updated_config.update(json)
+        model.set_config(updated_config)
 
 
 # --- pieces --- #

--- a/app/pentomino/static/js/pentomino.js
+++ b/app/pentomino/static/js/pentomino.js
@@ -7,8 +7,14 @@ $(document).ready(function () {
 
     // parameters for random initial state
     // (state is generated once the configuration is received)
-    const N_OBJECTS = 5;
+    const N_OBJECTS = 10;
     const N_GRIPPERS = 0; // no pre-generated gripper
+
+    const CONFIG = {
+        "move_step": 0.5,
+        "width": 25,
+        "height": 25
+    };
 
     // --- create a socket --- //
     // don't connect yet
@@ -40,6 +46,7 @@ $(document).ready(function () {
     });
 
     socket.on("joined_room", (data) => {
+        socket.emit("load_config", CONFIG);
         console.log(`Joined room ${data.room_id} as client ${data.client_id}`);
     })
 
@@ -53,7 +60,7 @@ $(document).ready(function () {
     var setup_complete = false;
     socket.on("update_config", (config) => {
         // only do setup once (reconnections can occur, we don't want to reset the state every time)
-        if (!setup_complete) {
+        if (!setup_complete && custom_config_is_applied(CONFIG, config)) {
             // ask model to load a random state
             socket.emit("random_init", {"n_objs": N_OBJECTS,
                                         "n_grippers": N_GRIPPERS,
@@ -78,6 +85,12 @@ $(document).ready(function () {
     socket.onAny((eventName, ...args) => {
         console.log(eventName, args);
     });
+
+    function custom_config_is_applied(custom_config, config_update) {
+        return Object.keys(custom_config).every(key => {
+            return config_update[key] == custom_config[key];
+        });
+    }
 
     // --- stop and start drawing --- //
     function start() {

--- a/app/pentomino/static/js/pentomino.js
+++ b/app/pentomino/static/js/pentomino.js
@@ -10,7 +10,7 @@ $(document).ready(function () {
     const N_OBJECTS = 10;
     const N_GRIPPERS = 0; // no pre-generated gripper
 
-    const CONFIG = {
+    const CUSTOM_CONFIG = {
         "move_step": 0.5,
         "width": 25,
         "height": 25
@@ -46,7 +46,7 @@ $(document).ready(function () {
     });
 
     socket.on("joined_room", (data) => {
-        socket.emit("load_config", CONFIG);
+        socket.emit("load_config", CUSTOM_CONFIG);
         console.log(`Joined room ${data.room_id} as client ${data.client_id}`);
     })
 
@@ -60,7 +60,8 @@ $(document).ready(function () {
     var setup_complete = false;
     socket.on("update_config", (config) => {
         // only do setup once (reconnections can occur, we don't want to reset the state every time)
-        if (!setup_complete && custom_config_is_applied(CONFIG, config)) {
+        if (!setup_complete && custom_config_is_applied(CUSTOM_CONFIG,
+                                                        config)) {
             // ask model to load a random state
             socket.emit("random_init", {"n_objs": N_OBJECTS,
                                         "n_grippers": N_GRIPPERS,

--- a/app/static/js/view/LayerView.js
+++ b/app/static/js/view/LayerView.js
@@ -82,6 +82,9 @@ $(document).ready(function () {
 		drawBg() {
 			// set updates
 			let ctx = this.bgCanvas.getContext("2d");
+			// important: https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/clearRect
+			// using beginPath() after clear() prevents odd behavior
+			ctx.beginPath();
 			ctx.fillStyle = "white";
 			ctx.lineStyle = "black";
 			ctx.lineWidth = 1;
@@ -93,6 +96,7 @@ $(document).ready(function () {
 			for (let row = 0; row <= this.rows; row++) {
 				ctx.moveTo(0, row*this.blockSize);
 				ctx.lineTo(this.canvasWidth, row*this.blockSize);
+				ctx.stroke();
 			}
 			// vertical lines
 			for (let col = 0; col <= this.cols; col++) {
@@ -118,6 +122,7 @@ $(document).ready(function () {
 		 */
 		drawObjs() {
 			// first draw targets
+			ctx.beginPath();
 			for (const obj of Object.values(this.targets))	{
 				// skip any gripped object here
 				if (obj.gripped) { continue; }
@@ -170,6 +175,7 @@ $(document).ready(function () {
 		drawGr() {
 			// set up
 			let ctx = this.grCanvas.getContext("2d");
+			ctx.beginPath();
 			for (const [grId, gripper] of Object.entries(this.grippers)) {
 				// draw any gripped object first (i.e. 'below' the gripper)
 				if (gripper.gripped) {

--- a/app/static/js/view/LayerView.js
+++ b/app/static/js/view/LayerView.js
@@ -87,7 +87,6 @@ $(document).ready(function () {
          * Draws a grid black on white as the background.
          */
         drawBg() {
-            // set updates
             let ctx = this.bgCanvas.getContext("2d");
             // important: https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/clearRect
             // using beginPath() after clear() prevents odd behavior
@@ -145,6 +144,7 @@ $(document).ready(function () {
          * Draw the (static) objects.
          */
         drawObjs() {
+            let ctx = this.objCanvas.getContext("2d");
             ctx.beginPath();
             // draw each object
             for (const obj of Object.values(this.objs))	{
@@ -154,7 +154,6 @@ $(document).ready(function () {
                 let blockMatrix = obj.block_matrix;
 
                 // call drawing helper functions with additional infos
-                let ctx = this.objCanvas.getContext("2d");
                 let params = {
                     x: obj.x,
                     y: obj.y,
@@ -179,7 +178,6 @@ $(document).ready(function () {
          * The gripper is used to navigate on the canvas and move objects.
          */
         drawGr() {
-            // set up
             let ctx = this.grCanvas.getContext("2d");
             ctx.beginPath()
             for (const [grId, gripper] of Object.entries(this.grippers)) {

--- a/model/config.py
+++ b/model/config.py
@@ -184,7 +184,8 @@ class Config:
         commentless_json = dict()
         for key, value in parsed_json.items():
             if not key.startswith("_"):
-                commentless_json[key] = value
-            elif isinstance(value, dict):
-                commentless_json[key] = Config.remove_json_comments(value)
+                if isinstance(value, dict):
+                    commentless_json[key] = Config.remove_json_comments(value)
+                else:
+                    commentless_json[key] = value
         return commentless_json

--- a/model/config.py
+++ b/model/config.py
@@ -3,7 +3,7 @@ Class to store settings such as board width, allowable actions, etc.
 """
 
 import json
-from os.path import exists
+from os.path import isfile
 
 
 class Config:
@@ -119,7 +119,7 @@ class Config:
         a 0 signifies the absence.
         @param filename 	path to json file
         """
-        if not exists(filename):
+        if not isfile(filename):
             raise ValueError("filename must be the path to an existing file")
         with open(filename, "r", encoding="utf-8") as infile:
             types = json.load(infile)
@@ -134,7 +134,7 @@ class Config:
             The key "type_config" mapping to a dictionary is mandatory.
         @return new Config instance with the given attributes
         """
-        if not exists(filename):
+        if not isfile(filename):
             raise ValueError("filename must be the path to an existing file")
         with open(filename, mode="r") as file:
             json_data = json.loads(file.read())

--- a/model/room_manager.py
+++ b/model/room_manager.py
@@ -22,15 +22,14 @@ class RoomManager:
         """
         return self.room_to_model.get(room_id) is not None
 
-    def add_room(self, room_id, config_file):
+    def add_room(self, room_id, config: dict):
         """
         Adds a room with a new model instance that has the default
         configuration.
         @param room_id identifier of the room for the new model instance
-        @param config_file  name of file containing a model configuration in
-            json format
+        @param config  model configuration as a dictionary
         """
-        new_model = Model(Config.from_json(config_file), self.socket, room_id)
+        new_model = Model(Config.from_dict(config), self.socket, room_id)
         self.room_to_model[room_id] = new_model
         self.room_to_clients[room_id] = list()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,96 @@
+import unittest
+
+import app.app
+from model.config import Config
+from tests.test_socketio import SocketTest
+
+
+class ConfigSocketTest(SocketTest):
+    """
+    Tests on loading and updating configs via socketio events.
+    """
+    @staticmethod
+    def get_default_config():
+        default_config = app.app.get_default_config()
+        default_config = Config.remove_json_comments(default_config)
+        return default_config
+
+    def load_config_from_file(self, filename):
+        """
+        @param filename config file, path is relative to the resource directory
+                        and without / in the beginning
+        @return tuple: (sent, received), where sent is the parsed json emitted
+                to the server and received is the server's response, i.e., the
+                (corrected) config
+        """
+        test_config = SocketTest.read_json(filename)
+        self.socketio_client.emit("load_config", test_config)
+        return test_config, self.socketio_client.get_received()
+
+    def test_load_empty_config(self):
+        config_to_load = dict()
+        default_config = ConfigSocketTest.get_default_config()
+
+        self.socketio_client.emit("load_config", config_to_load)
+        received = self.socketio_client.get_received()
+        received_config = received[0]["args"][0]
+
+        self.assertDictEqual(received_config, default_config)
+
+    def test_load_config_from_file(self):
+        """
+        test sending a configuration
+        """
+        test_config, received = self.load_config_from_file(
+            "config/test_config.json")
+
+        # make sure just one event was received
+        self.assertEqual(len(received), 1)
+        self.assertEqual(received[0]["name"], "update_config")
+
+        received_config = received[0]["args"][0]
+
+        # check the sent config is a subset of the received config
+        self.assertDictEqual(received_config, received_config | test_config)
+
+    def test_load_custom_config(self):
+        test_config = {"height": 42, "width": 42, "colors": ["black"],
+                          "prevent_overlap": False, "move_step": 10}
+
+        self.socketio_client.emit("load_config", test_config)
+        received = self.socketio_client.get_received()
+        received_config = received[0]["args"][0]
+
+        # check the sent config is a subset of the received config
+        self.assertDictEqual(received_config, received_config | test_config)
+
+    def test_update_empty_config(self):
+        # first load some custom config
+        test_config, received = self.load_config_from_file(
+            "config/test_config.json")
+        previous_config = received[0]["args"][0]
+        # then 'update' with an empty config (i.e., don't change anything)
+        test_config = dict()
+        self.socketio_client.emit("update_config", test_config)
+        received = self.socketio_client.get_received()
+        updated_config = received[0]["args"][0]
+
+        # make sure the settings sent initially were preserved
+        self.assertDictEqual(previous_config, updated_config)
+
+    def test_update_custom_config(self):
+        # first load some custom config
+        test_config, received = self.load_config_from_file(
+            "config/test_config.json")
+        previous_config = received[0]["args"][0]
+
+        # then update some keys
+        test_config = {"verbose": True, "rotation_step": 1,
+                       "lock_on_target": True,
+                       "type_config": {"tiny_dot": [[1]]}}
+        self.socketio_client.emit("update_config", test_config)
+        received = self.socketio_client.get_received()
+        updated_config = received[0]["args"][0]
+
+        # make sure initial settings were preserved and updates were applied
+        self.assertDictEqual(updated_config, previous_config | test_config)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3,6 +3,7 @@ import unittest
 
 from model.model import Model
 from model.config import Config
+from app.app import app, DEFAULT_CONFIG_FILE
 
 
 class FakeSocket:
@@ -18,9 +19,7 @@ class Test(unittest.TestCase):
     """
     tests on model
     """
-    config = Path(
-        "app/pentomino/static/resources/config/pentomino_config.json"
-    )
+    config = Path(app.config[DEFAULT_CONFIG_FILE])
 
     def get_model(self):
         return Model(

--- a/tests/test_socketio.py
+++ b/tests/test_socketio.py
@@ -125,30 +125,12 @@ class SocketTest(unittest.TestCase):
         self.socketio_client.emit("load_state", test_state)
         return test_state, self.socketio_client.get_received()
 
-    def load_config(self, filename):
-        """
-        @param filename config file, path is relative to the resource directory
-                        and without / in the beginning
-        @return tuple: (sent, received), where sent is the parsed json emitted
-                to the server and received is the server's response, i.e., the
-                (corrected) config
-        """
-        test_config = SocketTest.read_json(filename)
-        self.socketio_client.emit("load_config", test_config)
-        return test_config, self.socketio_client.get_received()
-
     def load_default_config_with_params(self, params):
         """
         Load a default Pentomino config, but modify the specified parameters.
         @param params   dict with settings that should be changed from default
-        @return tuple: (sent, received), where sent is the parsed json emitted
-                to the server and received is the server's response, i.e., the
-                (corrected) config
         """
-        default_config = SocketTest.read_json("config/pentomino_config.json")
-        default_config.update(params)
-        self.socketio_client.emit("load_config", default_config)
-        return default_config, self.socketio_client.get_received()
+        self.socketio_client.emit("load_config", params)
 
 
 class SocketEventTest(SocketTest):
@@ -202,22 +184,6 @@ class SocketEventTest(SocketTest):
         received = self.socketio_client.get_received()
         self.assertTrue(len(received[0]["args"][0]["grippers"]) == 0)
         self.assertTrue(len(received[0]["args"][0]["objs"]) == 0)
-
-    def test_load_config(self):
-        """
-        test sending a configuration
-        """
-        test_config, received = self.load_config("config/test_config.json")
-
-        # make sure just one event was received
-        self.assertEqual(len(received), 1)
-        self.assertEqual(received[0]["name"], "update_config")
-
-        # check the config was updated correctly. Here, the subset notion
-        # cannot be used because not all properties are sent back by the model.
-        for setting, value in test_config.items():
-            if setting in received[0]["args"][0]:
-                self.assertEqual(value, received[0]["args"][0][setting])
 
     def test_gripper_movement(self):
         """


### PR DESCRIPTION
* improve the remove_json_comments function: now removes comments recursively (also checks dicts within dicts), which simplyfies init from json: Before, the functions in some cases had to be called for json representing the config itself **and** json defining a type_config.
* permit making partial updates to the Config: a subset of config-keys can be sent to the server (using the "load_config" event as before), anything not specified will be assumed to stay at default
* extend error handling in Config for opening files
* squash a mean bug in LayerView: according to [Firefox](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/clearRect) `beginPath()` should always be called after `clear()` might have been used - which happens at each redraw in LayerView. All drawing functions now call `beginPath` once.
* style: use double quotes uniformly
* server-side DEFAULT_CONFIG_FILE is now read by app.py, but not from classes like RoomManager anymore
