### PR TITLE
Extend logview

### DIFF
--- a/app/pentomino/pentomino.py
+++ b/app/pentomino/pentomino.py
@@ -3,7 +3,7 @@ from flask import render_template, Blueprint, request, abort
 from flask_cors import cross_origin
 import json
 import os
-from time import time_ns
+from datetime import datetime
 
 
 def apply_config_to(app):
@@ -36,7 +36,7 @@ def save_log():
     # (1) can not be manipulated by a client
     # (2) has a negligible chance of collision
     # a timestamp is used
-    filename = str(time_ns()) + ".json"
+    filename = datetime.now().strftime("%y%m%d_%H%M%S_%f") + ".json"
     # check if "data_collection" directory exists, create if necessary
     save_path = "app/pentomino/static/resources/data_collection"
     if not os.path.exists(save_path):

--- a/app/pentomino/pentomino.py
+++ b/app/pentomino/pentomino.py
@@ -17,7 +17,6 @@ pentomino_bp = Blueprint('pentomino_bp', __name__,
                          static_folder='static',
                          url_prefix="/pentomino")
 
-
 @cross_origin
 @pentomino_bp.route("/", methods=["GET"])
 def pentomino():
@@ -36,8 +35,8 @@ def save_log():
     # as a filename that
     # (1) can not be manipulated by a client
     # (2) has a negligible chance of collision
-    # a simple timestamp is used
-    filename = str(time_ns() / 100) + ".json"
+    # a timestamp is used
+    filename = str(time_ns()) + ".json"
     # check if "data_collection" directory exists, create if necessary
     save_path = "app/pentomino/static/resources/data_collection"
     if not os.path.exists(save_path):

--- a/app/pentomino/static/js/pentomino.js
+++ b/app/pentomino/static/js/pentomino.js
@@ -32,7 +32,9 @@ $(document).ready(function () {
     const layerView = new document.LayerView(socket, bgLayer, objLayer, grLayer);
 
     // --- logger --- //
-    const logView = new document.LogView(socket);
+    // second parameter disables full state logging, significantly reducing
+    // log sizes while still keeping track of all changes.
+    const logView = new document.LogView(socket, false);
 
     // --- socket communication --- //
     socket.on("connect", () => {
@@ -46,7 +48,7 @@ $(document).ready(function () {
     socket.on("disconnect", () => {
         console.log("Disconnected from model server");
         // demo of the logView: send the logged data to the server
-        logView.addData("test", true);
+        logView.addTopLevelData("test", true);
         logView.sendData("/pentomino/save_log");
     });
 

--- a/app/static/js/view/LView.js
+++ b/app/static/js/view/LView.js
@@ -1,9 +1,51 @@
+/** TODO:
+ * All _getXXUpdates() functions (e.g., _getObjUpdates()) have no way of
+ * recognizing deleted objects/targets/grippers: they check the received update
+ * and compare to the internally saved last state, then compile a reduced
+ * update out of any entities that differ between update and saved state.
+ * -> Detecting an entity was removed is easy, the _getXXUpdates() functions
+ * would simply have to check whether some of the entities in the saved state
+ * are missing in an update.
+ * -> But the log consists of EXISTING entities with their updated properties.
+ * How to log a no-longer-existing entity?
+ * One option would be to introduce a special type of log entry for this.
+ * Or every entry could have the 'event' key (the 'registeredLocalEvents'
+ * already have that) stating the type, like 'update' or 'deletion'.
+ * For example:
+ * [
+      2183, <- timestamp
+      {
+        "event": "update", <- type of update
+        "grippers": {
+          "fVHMwdLePCE2Vlq5AAAB": {
+            "x": 9.5,
+            "y": 10
+          }
+        }
+      }
+    ],
+    [
+      2701,
+      {
+        "event": "deletion",
+        "grippers": {
+          "fVHMwdLePCE2Vlq5AAAB": { <- could also be reduced to id of entity
+            "x": 9.5,
+            "y": 10
+          }
+        }
+      }
+    ]
+ */
+
+
 $(document).ready(function () {
     /**
-     * Logger class. Relies on events exchanged between a specific client and server.
-     * Starts logging as soon as the client receives the first state
+     * Logger class. Relies on events exchanged between a specific client and
+     * server. Starts logging as soon as the client receives the first state
      * @param {Socket io connection to the server} modelSocket
-     * @param {set true to save the full state at every change, false to only log the update}
+     * @param {set true to save the full state at every change, false to only
+     *         log the update}
      */
     this.LogView = class LogView {
         constructor(modelSocket, logFullState=true) {
@@ -313,7 +355,8 @@ $(document).ready(function () {
         }
 
         /**
-         * Currently has no way of detecting "deleted" objects.
+         * Currently has no way of detecting "deleted" objects, see TODO at
+         * the top of the file.
          * Gripped objects have the "gripped" property set to true, so the
          * LayerView knows not to draw them on the object layer
          * @return Object mapping obj ids to changed objs
@@ -342,7 +385,8 @@ $(document).ready(function () {
         }
 
         /**
-         * Currently has no way of detecting "deleted" targets.
+         * Currently has no way of detecting "deleted" targets, see TODO at
+         * the top of the file.
          * @return Object mapping target ids to changed targets
          */
         _getTargetUpdates(newTargets) {
@@ -369,6 +413,8 @@ $(document).ready(function () {
         }
 
         /**
+         * Currently has no way of detecting "deleted" grippers, see TODO at
+         * the top of the file.
          * @return object mapping gripper ids to changed grippers
          */
         _getGrUpdates(newGrs) {

--- a/app/static/js/view/LView.js
+++ b/app/static/js/view/LView.js
@@ -368,45 +368,65 @@ $(document).ready(function () {
             return updates;
         }
 
-        //TODO
         /**
          * @return object mapping gripper ids to changed grippers
          */
         _getGrUpdates(newGrs) {
-            /*let updates = new Object();
+            let updates = new Object();
             for (let [id, gr] of Object.entries(newGrs)) {
                 if (this.currentGrippers[id]) {
                     // check if any property changed
-                    for (let [prop, value] of Object.entries(obj)) {
-                        if (prop == "gripped" && value != null) {
-                            //TODO
+                    for (let [prop, value] of Object.entries(gr)) {
+                        // check if new object is gripped
+                        if (prop == "gripped" && this._grippedStateChanged(
+                                gr, this.currentGrippers[id])) {
+                            console.log(value)
+                            updates[id] = gr;
+                            break;
                         }
                         // skip arrays for now. Only occur for block_matrix
                         // which does not change without modification to other
                         // properties
                         if (!(value instanceof Array) &&
-                            (this.currentObjs[id][prop] != value)) {
-                            updates[id] = obj;
+                            (this.currentGrippers[id][prop] != value)) {
+                            updates[id] = gr;
                             break;
                         }
                     }
                 } else {
-                    // new object
-                    updates[id] = obj;
+                    // new gripper
+                    updates[id] = gr;
                 }
             }
-            return updates;*/
-            return newGrs;
+            return updates;
         }
 
         /**
-         * TODO: not yet implemented
+         * TODO: not yet implemented: to further reduce the log size, only
+         * changed configurations could be logged here
          * @return object containing changed configurations
          */
         _getConfigUpdates(newConfig) {
             //console.log("oldConf", this.currentConfig)
             //console.log("newConf", newConfig)
             return newConfig;
+        }
+
+        /**
+         * Compare the "gripped" property of two grippers.
+         * @return true if an object was gripped, ungripped or a different
+         *      object is gripped.
+         */
+        _grippedStateChanged(newGr, oldGr) {
+            // true if:
+            // (1) new gripper gripped an object
+            // (2) new gripper ungripped object
+            // (3) both grippers grip an object, but different ones (not an
+            // expected case, but is covered here for completeness
+            return ((newGr["gripped"] != null) && (oldGr["gripped"] == null)) ||
+                   ((newGr["gripped"] == null) && (oldGr["gripped"] != null)) ||
+                   ((newGr["gripped"] == null) && (oldGr["gripped"] != null) &&
+                    (newGr["gripped"]["id_n"] != oldGr["gripped"]["id_n"]));
         }
 
         /**

--- a/app/static/js/view/LView.js
+++ b/app/static/js/view/LView.js
@@ -18,6 +18,11 @@ $(document).ready(function () {
             this.currentObjs = new Object();
             this.currentGrippers = new Object();
             this.currentConfig = new Object();
+            this.registeredLocalEvents = [
+                "emitMessage",
+                "startAction",
+                "stopAction"
+            ];
             // start listening to events
             this._initEventListeners();
         }
@@ -27,22 +32,22 @@ $(document).ready(function () {
             this._initSocketEvents();
             // register document event listeners
             document.addEventListener("logSegment", e => {
-                if (e.detail["segmentTitle"] != undefined && e.detail["segmentTitle"] != null) {
-                    this.addSegment(e.detail["segmentTitle"].toString(), e.detail["additionalData"]);
+                if (e.detail["segmentTitle"] != undefined &&
+                        e.detail["segmentTitle"] != null) {
+                    this.createSegment(e.detail["segmentTitle"].toString(),
+                                       e.detail["additionalData"]);
                 } else {
-                    console.log("Error: No segment title sent with logSegment event");
+                    console.log("Error: No segment title sent with logSegment",
+                        " event");
                 }
             });
-            document.addEventListener("emitMessage", e => {
-                // append the message as a regular event to the log
-                let timeOffset;
-                if (!this.startTime) {
-                    timeOffset = -1;
-                } else {
-                    timeOffset = Date.now() - this.startTime;
-                }
-                this._addSnapshot(timeOffset, e.detail);
-            })
+            for (let metaEvent of this.registeredLocalEvents) {
+                document.addEventListener(metaEvent, e => {
+                    // add event name and details to log
+                    e.detail["event"] = metaEvent;
+                    this._addTimestamp(this._getTimestamp(), e.detail);
+                });
+            }
         }
 
         /**
@@ -55,7 +60,7 @@ $(document).ready(function () {
             });
             this.socket.on("update_state", (state) => {
                 // Assumes the logging starts at first 'update_state' event.
-                let timeOffset;
+                let timeStamp;
                 if (!this.startTime) {
                     // don't start logging if an empty state was sent
                     if (Object.keys(state["objs"]).length == 0 &&
@@ -63,37 +68,51 @@ $(document).ready(function () {
                         return;
                     }
                     this.startTime = Date.now();
-                    timeOffset = 0;
+                    timeStamp = 0;
                 } else {
-                    timeOffset = Date.now() - this.startTime;
+                    timeStamp = this._getTimestamp()
                 }
                 if (this.logFullState) {
                     this.currentObjs = state["objs"];
                     this.currentGrippers = state["grippers"];
-                    this._addSnapshot(timeOffset, this._getFullState());
+                    this._addTimestamp(timeStamp, this._getFullState());
+                }
+                else {
+                    // save snapshot of changes to the state
+                    this._addTimestamp(timeStamp,
+                                       this._getStateUpdates(state));
+                    this.currentObjs = state["objs"];
+                    this.currentGrippers = state["grippers"];
                 }
             })
             this.socket.on("update_grippers", (grippers) => {
                 if (this.startTime) {
-                    let timeOffset = Date.now() - this.startTime;
                     if (this.logFullState) {
                         this.currentGrippers = grippers;
-                        this._addSnapshot(timeOffset, this._getFullState());
+                        this._addTimestamp(this._getTimestamp(),
+                                           this._getFullState());
                     } else {
                         // reduce the log size if a gripper id is given
-                        if (this.grId && grippers[this.grId]) {
-                            if (grippers[this.grId].gripped) {
-                                // log the id of the gripped object
-                                this._addSnapshot(timeOffset, {"gripper": {
-                                    "gripped": Object.keys(grippers[this.grId].gripped)[0]}});
-                            } else {
-                                this._addSnapshot(timeOffset, {"gripper": {
+                        if (this.grId) {
+                            if (grippers[this.grId]) {
+                                let update = new Object();
+                                update[this.grId] = {
                                     "x": grippers[this.grId]["x"],
                                     "y": grippers[this.grId]["y"]
-                                }});
+                                };
+                                if (grippers[this.grId].gripped) {
+                                    update[this.grId]["gripped"] = grippers[this.grId].gripped;
+                                }
+                                // log the id of the gripped object
+                                this._addTimestamp(this._getTimestamp(), {
+                                    "grippers": update
+                                });
                             }
                         } else {
-                            this._addSnapshot(timeOffset, {"gripper": grippers});
+                            this._addTimestamp(this._getTimestamp(), {
+                                "grippers": this._getGrUpdates(grippers)
+                            });
+                            this.currentGrippers = grippers;
                         }
                     }
                 }
@@ -101,28 +120,37 @@ $(document).ready(function () {
             });
             this.socket.on("update_objs", (objs) => {
                 if (this.startTime) {
-                    let timeOffset = Date.now() - this.startTime;
                     if (this.logFullState) {
                         this.currentObjs = objs;
-                        this._addSnapshot(timeOffset, this._getFullState());
+                        this._addTimestamp(this._getTimestamp(), this._getFullState());
+                    }
+                    else {
+                        this._addTimestamp(this._getTimestamp(), {
+                            "objs": this._getObjUpdates(objs)
+                        });
+                        this.currentObjs = objs;
                     }
                 }
             });
             this.socket.on("update_config", (config) => {
                 if (this.startTime) {
-                    let timeOffset = Date.now() - this.startTime;
                     if (this.logFullState) {
                         this.currentConfig = config;
-                        this._addSnapshot(timeOffset, this._getFullState());
+                        this._addTimestamp(this._getTimestamp(),
+                                           this._getFullState());
                     } else {
-                        this._addSnapshot(timeOffset, {"config": config});
+                        this._addTimestamp(this._getTimestamp(), {
+                            "config": this._getConfigUpdates(config)
+                        });
+                        this.currentConfig = config;
                     }
                 } else if (this.logFullState) {
-                    // save the config for later in case it arrived before the first state
+                    // save config in case it arrived before the first state
                     this.currentConfig = config;
                 } else {
-                    // save the config once in the beginning in case it arrived before the first state
-                    this._addSnapshot(-1, {"config": config});
+                    // save config once in the beginning in case it arrived
+                    // before the first state
+                    this._addTimestamp(-1, {"config": config});
                 }
             });
         }
@@ -130,15 +158,17 @@ $(document).ready(function () {
         // --- add, change, delete data --- //
 
         /**
-         * Make a cut and store the data logged so far (or since the last segment) as a
-         * segment with key segmentTitle. Optionally add some extra info to the segment.
-         * @param {key to store the logged data with, can not be "log"} segmentTitle
-         * @param {optional data object to store with the new segment, default: null} additionalData
+         * Make a cut and store the data logged so far (or since the last
+         * segment) as a segment with key segmentTitle. Optionally add some
+         * extra info to the segment.
+         * @param {key to the logged data, can not be "log"} segmentTitle
+         * @param {optional: data object to new segment} additionalData
          */
-        addSegment(segmentTitle, additionalData=null) {
+        createSegment(segmentTitle, additionalData=null) {
             if (segmentTitle == "log") {
                 // 'log' key is reserved for the collected event data
-                console.log("Error at LogView.createSegment(): 'log' is reserved, use another segment name");
+                console.log("Error at LogView.createSegment():",
+                    " 'log' is reserved, use another segment name");
             } else {
                 this.data[segmentTitle] = {"log": this.data["log"]};
                 if (additionalData) {
@@ -146,7 +176,8 @@ $(document).ready(function () {
                         if (key != "log") {
                             this.data[segmentTitle][key] = value;
                         } else {
-                            console.log("Skipping key 'log' of additional data in LogView.addSegment()");
+                            console.log("Skipping key 'log' of additional data",
+                                " in LogView.createSegment()");
                         }
                     });
                 }
@@ -158,39 +189,42 @@ $(document).ready(function () {
          * Add additional data to the current log. Will be saved at
          * the top-level of the log object.
          * @param {string, identifier for the data, 'log' is reserved} key
-         * @param {data to save, can be any json-friendly format, e.g. object, list, string} data
+         * @param {data to save, can be any json-friendly format, e.g. object,
+         *         list, string} data
          */
-        addData(key, data) {
+        addTopLevelData(key, data) {
             if (key == "log") {
                 // 'log' key is reserved for the collected event data
-                console.log("Error at LogView.addData(): Cannot manually add data with reserved key 'log'.");
+                console.log("Error at LogView.addTopLevelData():",
+                    " Cannot manually add data with reserved key 'log'.");
             } else {
                 this.data[key] = data;
             }
         }
 
         /**
-         * Func: addDataToSegment
          * Save additional data to an already created segment.
-         *
-         * Params:
-         * segment - name of an existing segment to save the _data_ to
-         * key - string, identifier for _data_, 'log' is reserved
-         * data - data to save, can be any json-friendly format, e.g. object, array, _str_
+         * @param {name of an existing segment to save the data to} segment
+         * @param {string, identifier for the data, 'log' is reserved} key
+         * @param {data to save, can be any json-friendly format, e.g. object,
+         *         list, string} data
          */
-        addDataToSegment(segment, key, data) {
+        addSegmentData(segment, key, data) {
             if (!this.data[segment]) {
-                console.log(`Error at LogView.addDataToSegment(): segment ${segment} does not exist.`);
+                console.log("Error at LogView.addSegmentData():",
+                    ` segment ${segment} does not exist.`);
             } else if (key == "log") {
                 // 'log' key is reserved for the collected event data
-                console.log("Error at LogView.addDataToSegment(): Cannot manually add data with reserved key 'log'.");
+                console.log("Error at LogView.addSegmentData():",
+                    " Cannot manually add data with reserved key 'log'.");
             } else {
                 this.data[segment][key] = data;
             }
         }
 
         /**
-         * Delete the current log and reset the saved state except for the configuration.
+         * Delete the current log and reset the saved state except for the
+         * configuration.
          */
         clearLog() {
             this.data["log"] = new Array();
@@ -203,21 +237,19 @@ $(document).ready(function () {
 
         /**
          * Save the data on the server.
-         * @param {route to POST the collected data to, for example: /save_log} endpoint
-         * @return true at success
+         * @param {route to POST the collected data to, default: /save_log} endpoint
          */
-        sendData(endpoint) {
+        sendData(endpoint="/save_log") {
             fetch(new Request(endpoint, {
                 method:"POST",
                 headers: { "Content-Type": "application/json;charset=utf-8" },
-                body:JSON.stringify(this.data)}))
+                body:JSON.stringify(this.data)
+            }))
             .then(response => {
                 if (!response.ok) {
                     console.log("Error saving log data!");
-                    return true;
                 } else {
                     console.log("Saved log data to the server.");
-                    return false;
                 }
             });
         }
@@ -225,20 +257,113 @@ $(document).ready(function () {
         // --- helper functions --- //
 
         /**
-         * @return a state object containing the objects, grippers and config as received last
+         * Create a timestamp in ms passed since the starting point. If logging
+         * has not yet started, returns -1.
+         * @return time passed since log start in ms
+         */
+        _getTimestamp() {
+            if (!this.startTime) {
+                return -1;
+            }
+            return Date.now() - this.startTime;
+        }
+
+        /**
+         * @return state containing objs, grippers and config received last
          */
         _getFullState() {
-            return {"objs": this.currentObjs,
-                    "grippers": this.currentGrippers,
-                    "config": this.currentConfig};
+            return {
+                "objs": this.currentObjs,
+                "grippers": this.currentGrippers,
+                "config": this.currentConfig
+            };
+        }
+
+        /**
+         * @return a state object containing only changed objs and grippers
+         */
+        _getStateUpdates(newState) {
+            return {
+                "objs": this._getObjUpdates(newState["objs"]),
+                "grippers": this._getGrUpdates(newState["grippers"])};
+        }
+
+        /**
+         * Currently has no way of detecting "deleted" objects.
+         * Gripped objects have the "gripped" property set to true, so the
+         * LayerView knows not to draw them on the object layer
+         * @return object mapping obj ids to changed objs
+         */
+        _getObjUpdates(newObjs) {
+            let updates = new Object();
+            for (let [id, obj] of Object.entries(newObjs)) {
+                if (this.currentObjs[id]) {
+                    // check if any property changed
+                    for (let [prop, value] of Object.entries(obj)) {
+                        // skip arrays for now. Only occur for block_matrix
+                        // which does not change without modification to other
+                        // properties
+                        if (!(value instanceof Array) &&
+                                (this.currentObjs[id][prop] != value)) {
+                            updates[id] = obj;
+                            break;
+                        }
+                    }
+                } else {
+                    // new object
+                    updates[id] = obj;
+                }
+            }
+            return updates;
+        }
+
+        //TODO
+        /**
+         * @return object mapping gripper ids to changed grippers
+         */
+        _getGrUpdates(newGrs) {
+            /*let updates = new Object();
+            for (let [id, gr] of Object.entries(newGrs)) {
+                if (this.currentGrippers[id]) {
+                    // check if any property changed
+                    for (let [prop, value] of Object.entries(obj)) {
+                        if (prop == "gripped" && value != null) {
+                            //TODO
+                        }
+                        // skip arrays for now. Only occur for block_matrix
+                        // which does not change without modification to other
+                        // properties
+                        if (!(value instanceof Array) &&
+                            (this.currentObjs[id][prop] != value)) {
+                            updates[id] = obj;
+                            break;
+                        }
+                    }
+                } else {
+                    // new object
+                    updates[id] = obj;
+                }
+            }
+            return updates;*/
+            return newGrs;
+        }
+
+        /**
+         * TODO: not yet implemented
+         * @return object containing changed configurations
+         */
+        _getConfigUpdates(newConfig) {
+            //console.log("oldConf", this.currentConfig)
+            //console.log("newConf", newConfig)
+            return newConfig;
         }
 
         /**
          * Add a single data update with a timestamp to the log.
-         * @param {timestamp to associate the data with, e.g. time passed since log start} timestamp
+         * @param {timestamp, e.g. time passed since log start} timestamp
          * @param {update to save} data
          */
-        _addSnapshot(timestamp, data) {
+        _addTimestamp(timestamp, data) {
             this.data["log"].push([timestamp, data]);
         }
     }; // class LogView end


### PR DESCRIPTION
* (manually) merge updates to LogView / LView made on the `pento_fractions` branch back into `main`
* log targets
* implement _getGrUpdates function for partial logging (i.e., only log objects with actual changes, not the whole state for each snapshot) of grippers
* _getConfigUpdates is left unimplemented in this PR. Since the config is not expected to change frequently, the expected log size reduction is minimal, so it didn't seem an urgent issue. The idea would be to only log config keys that changed in an update

Fixes #6 
