### PR TITLE
only apply rotation and flipping if the block matrix is loaded from type config

### DIFF
--- a/golmi/server/obj.py
+++ b/golmi/server/obj.py
@@ -154,10 +154,13 @@ class Obj:
                 f"Object construction failed, key {mandatory_key} missing"
             )
         bm = None
+        apply_transformations = False
         if type_config:
             bm = type_config[source_dict["type"]]
+            apply_transformations = True
         if "block_matrix" in source_dict:
             bm = source_dict["block_matrix"]
+            apply_transformations = False
         if not bm:
             raise Exception("Either provide type_config or block_matrix")
         # create new object from the mandatory keys
@@ -169,13 +172,14 @@ class Obj:
             block_matrix=bm
         )
 
-        # process optional info
-        if "rotation" in source_dict and source_dict["rotation"] != 0:
-            new_obj.rotate(float(source_dict["rotation"]))
+        if apply_transformations is True:
+            # process optional info
+            if "rotation" in source_dict and source_dict["rotation"] != 0:
+                new_obj.rotate(float(source_dict["rotation"]))
 
-        # flip the object if "mirrored" is true in the dictionary
-        if "mirrored" in source_dict and source_dict["mirrored"]:
-            new_obj.flip()
+            # flip the object if "mirrored" is true in the dictionary
+            if "mirrored" in source_dict and source_dict["mirrored"]:
+                new_obj.flip()
 
         # apply color
         if "color" in source_dict:


### PR DESCRIPTION
since matrix manipulation on objects are in-place operations, we don't need to apply rotation and flipping on a block matrix if it is loaded from a source_dict since they are already in the right position. 
Right now we are modifying matrices that are already in the correct position and this means that the state that is loaded looks different from the one that was saved.
This pull requests fixes this problem allowing flipping and rotation only if the block matrix is loaded from the type config file and is not present in the source_dict